### PR TITLE
改善一些触发和视频下载逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ ffmpeg_path = "/usr/local/bin"
 
 | 配置项 | 必填 | 默认值 | 说明 |
 |:-----:|:----:|:----:|:----:|
-| super_admins | 是 | [] | 管理员QQ号列表 |
+| bili_super_admins | 是 | [] | 管理员QQ号列表，格式：[(int)] |
 | ffmpeg_path | 否 | [] | FFmpeg的路径，如果为空则自动从PATH中查找 |
 
 ## 🎉 使用

--- a/nonebot_plugin_bili2mp4/main.py
+++ b/nonebot_plugin_bili2mp4/main.py
@@ -13,6 +13,7 @@ from typing import List, Optional, Set, Tuple
 from urllib.parse import parse_qs, unquote, urlparse
 
 from nonebot import logger, on_message, require
+from nonebot.permission import SUPERUSER
 from nonebot.adapters.onebot.v11 import (
     Bot,
     Event,
@@ -446,6 +447,31 @@ def _build_format_candidates(height_limit: int, size_limit_mb: int) -> List[str]
     # 默认格式
     return ["bv*+ba/best"]
 
+def format_selector(ctx):
+    """ Select the best video and the best audio that won't result in an mkv.
+    NOTE: This is just an example and does not handle all cases """
+
+    # formats are already sorted worst to best
+    formats = ctx.get('formats')[::-1]
+
+    # acodec='none' means there is no audio
+    best_video = next(f for f in formats
+                      if f['vcodec'] != 'none' and f['vcodec'] != 'av01.0.00M.10.0.110.01.01.01.0' and f['acodec'] == 'none')
+
+    # find compatible audio extension
+    audio_ext = {'mp4': 'm4a', 'webm': 'webm'}[best_video['ext']]
+    # vcodec='none' means there is no video
+    best_audio = next(f for f in formats if (
+        f['acodec'] != 'none' and f['vcodec'] == 'none' and f['ext'] == audio_ext))
+
+    # These are the minimum required fields for a merged format
+    yield {
+        'format_id': f'{best_video["format_id"]}+{best_audio["format_id"]}',
+        'ext': best_video['ext'],
+        'requested_formats': [best_video, best_audio],
+        # Must be + separated list of protocols
+        'protocol': f'{best_video["protocol"]}+{best_audio["protocol"]}'
+    }
 
 def _download_with_ytdlp(
     url: str, cookie: str, out_dir, height_limit: int, size_limit_mb: int
@@ -471,12 +497,13 @@ def _download_with_ytdlp(
     for i, fmt in enumerate(candidates):
         headers = _build_browser_like_headers()
         ydl_opts = {
-            "format": fmt,
+            "format": format_selector,
             "outtmpl": str(out_dir / "%(title).80s [%(id)s].%(ext)s"),
             "noplaylist": True,
             "merge_output_format": "mp4",
             "quiet": False,
             "no_warnings": False,
+            "max_filesize" : size_limit_mb*1024*1024,  # MB in bytes
             "http_headers": headers,
             "extractor_args": {
                 "bili": {
@@ -696,12 +723,9 @@ group_listener = on_message(priority=100, block=False)
 
 
 @group_listener.handle()
-async def handle_group(bot: Bot, event: Event):
+async def handle_group(bot: Bot, event: GroupMessageEvent):
     try:
         _init_plugin()
-
-        if not isinstance(event, GroupMessageEvent):
-            return
 
         group_id = int(event.group_id)
         if group_id not in enabled_groups:
@@ -734,15 +758,12 @@ async def handle_group(bot: Bot, event: Event):
 
 
 # 私聊控制
-ctrl_listener = on_message(priority=50, block=False)
+ctrl_listener = on_message(priority=50, permission=SUPERUSER, block=False)
 
 
 @ctrl_listener.handle()
-async def handle_private(bot: Bot, event: Event):
+async def handle_private(bot: Bot, event: PrivateMessageEvent):
     _init_plugin()
-
-    if not isinstance(event, PrivateMessageEvent):
-        return
 
     try:
         uid = int(event.user_id)


### PR DESCRIPTION
1. 修改配置项说明 
2. 优化触发逻辑
```ruby
main.py 
line 726
async def handle_group(bot: Bot, event: GroupMessageEvent):

line 761
ctrl_listener = on_message(priority=50, permission=SUPERUSER, block=False)


@ctrl_listener.handle()
async def handle_private(bot: Bot, event: PrivateMessageEvent):
```

 bot自带有个SUPERUSER变量，.env设置格式 SUPERUSERS=[(str)] ；私聊/群聊检测可以提前，这样能减少一些误触（

3. 优化下载逻辑
```ruby
main.py 
line 506
"max_filesize" : size_limit_mb*1024*1024, # MB in bytes
```
配置项里加这个变量应该可以在下载前判断文件大小是否超过设定，原先好像是先下载然后看文件大小，这样能省点流量（

4. 试图修复无法发送视频的bug
- 个人测试后推测，b站视频播放量超过一定阈值，原视频会再被压缩成av1格式，可能是因为一般不会有该格式的内置编码器，在windows和qq中都不能自动生成缩略图，进而导致发送视频失败，如图：
<img width="1086" height="78" alt="PixPin_2026-02-19_16-02-06" src="https://github.com/user-attachments/assets/3f2b6e44-218e-4802-9a79-0ff5b32968f9" />

- 通过yt-dlp自带的下载信息列表也可以看出，av1优先级很高，在列表最下方（不太清楚具体规则算法）；一般如果format设置"bv*+ba/best"等，选择最优视频最优音频时都会选到这个视频格式；信息列表如图：
<img width="664" height="324" alt="PixPin_2026-02-19_16-13-11" src="https://github.com/user-attachments/assets/50807526-cfab-4234-8f8c-7de4b9854d1b" />

（序号1：avc格式；序号2：hevc；序号3：av1）

实际下载时大概也是根据这样的表选择，所以根据 [说明文档中自定义selector](https://github.com/yt-dlp/yt-dlp?tab=readme-ov-file#use-a-custom-format-selector)，新增屏蔽该格式的条件而后生成表单（见line 450的函数，line 459 的屏蔽条件），然后下载的就是id 30077+30280 组合的视频，就可以正常发送

有一些功能比如限制只下载720p以下的视频（实际使用时，很多竖屏视频会超过1080p，所以个人感觉这个限制不太实用）、或者更优化的修改下载表单或屏蔽格式的逻辑，完全是按照个人使用需求改的，大佬这块可以直接改